### PR TITLE
fix: modal can't be scroll on some screen

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -280,7 +280,7 @@ i.close-btn {
   }
 }
 .backdrop {
-    overflow: hidden;
+    overflow: auto;
     position: fixed; 
     top: 0;
     left: 0;
@@ -741,6 +741,10 @@ body {
     background: rgba(3, 12, 20, 1);
     background-image: none!important;
     min-height: unset;
+  }
+
+  &:has(.backdrop) {
+    overflow: hidden;
   }
 
   // &::-webkit-scrollbar {


### PR DESCRIPTION
the scroll bar is attached to body, that's why the user can't scroll the modal. The fix is to enable scroll on backrop and hide the scroll on body when modal is open


https://bitcoincom.slack.com/archives/CAUK6FUR0/p1734408244883259?thread_ts=1734408244.883259&cid=CAUK6FUR0